### PR TITLE
fix: Don't send allowCache to java-invoke-local server

### DIFF
--- a/src/lambda/handler-runner/java-runner/JavaRunner.js
+++ b/src/lambda/handler-runner/java-runner/JavaRunner.js
@@ -75,8 +75,7 @@ export default class JavaRunner {
         data: input,
         function: this.#functionName,
         jsonOutput: true,
-        serverlessOffline: true,
-        allowCache: this.#allowCache,
+        serverlessOffline: true
       })
 
       const httpOptions = {


### PR DESCRIPTION
## Description

We were running "java-invoke-local --server" and "serverless offline" as suggested for faster local invocations to the java lambda functions. But every single request we made ended with the following exception.

`groovy.lang.MissingPropertyException: No such property: allowCache for class: serverless.jvm.plugin.InvokeRequest`

After taking a look at both source codes, I think it is because the java runner sends the unsupported property "allowCache" to the java-invoke-local server accidentally.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

java-invoke-local doesn't support the property "allowCache".
https://github.com/bytekast/serverless-toolkit/blob/44d94008c5f0e7b6953d7d010f26e0490cd3814a/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/InvokeRequest.groovy#L9

But JavaRunner.js sends it as a part of the body data to the java-invoke-local server.
https://github.com/dherault/serverless-offline/blob/353b6c6ecb3459dd32ff1c74baca9192dc369c1a/src/lambda/handler-runner/java-runner/JavaRunner.js#L79

It causes exceptions that prevent us from testing the java lambda functions with faster local invocations. So we made this simple change to just remove "allowCache" from the sending object.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We made this change to serverless offline and try it again along with running "java-invoke-local --server" as before. Everything works as expected. We don't see it affecting any other areas.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12808025/158000117-38452eb0-215e-481e-ac10-24fe1a908c15.png)
![image](https://user-images.githubusercontent.com/12808025/158000150-231a223a-b180-42ef-941c-76e7cb9bbd82.png)
